### PR TITLE
Fix `.constructor` property of (p)react components, fixes #16

### DIFF
--- a/react.js
+++ b/react.js
@@ -14,7 +14,7 @@ function toReact (Component, react) {
   }
 
   Clx.prototype = Object.create(react.Component.prototype)
-  Clx.prototype.constructor = react.Component
+  Clx.prototype.constructor = Clx
 
   Clx.prototype.componentDidMount = function componentDidMount () {
     if (!this.comp.element) {


### PR DESCRIPTION
Preact uses the constructor property to associate the correct component
with elements.