### PR TITLE
add angular.js adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Not all languages and frameworks are supported yet; PRs to support more
 frameworks support are very welcome!
 - [React / Preact](#react-preact)
 - [Choo](#choo)
+- [Angular.js](#angular.js)
 - [Angular](#angular)
 - Ember
 - Cycle
@@ -69,6 +70,10 @@ customElements.define('custom-button', CustomButton);
 var button = document.createElement('custom-button')
 document.body.appendChild(button)
 ```
+
+## Angular.js
+
+See [nanocomponent-adapters-angularjs](https://github.com/kareniel/nanocomponent-adapters-angularjs).
 
 ## Angular
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+module.exports.customElementV0 = require('./custom-element-v0')
+module.exports.customElementV1 = require('./custom-element-v1')
+module.exports.angularjs = require('nanocomponent-adapters-angularjs')
+module.exports.angular = require('./angular')
+module.exports.react = require('./react')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "NODE_ENV=production bankai example --open",
     "test": "standard && npm run deps"
   },
-  "dependencies": {},
+  "dependencies": {
+    "nanocomponent-adapters-angularjs": "^1.0.0"
+  },
   "devDependencies": {
     "@angular/core": "^2.0.0",
     "bankai": "^8.1.1",


### PR DESCRIPTION
this pr adds an export to an angular.js (1.x) adapter and gets the ball rolling on #18.

- export every local adapter in main file
- export require('nanocomponent-adapters-angularjs')
- update readme